### PR TITLE
[maint] mark developement version as "x.y.z+"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Name: testify
-Version: 0.2.0
+Version: 0.2.0+
 Date: 2019-03-16
 Title: Testify - enhanced test suite stuff
 Author: Andrew Janke <floss@apjanke.net>


### PR DESCRIPTION
See https://savannah.gnu.org/bugs/?55829