### PR TITLE
add depends on octave 4.4 for classdef

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,7 @@ Author: Andrew Janke <floss@apjanke.net>
 Maintainer: Andrew Janke <floss@apjanke.net>
 Description: Enhanced replacements for test, __run_test_suite__, and related code
 Categories: test
+Depends: octave (>= 4.4)
 Suggested: doctest (>= 0.6.1)
 Url: https://github.com/apjanke/octave-testify
 


### PR DESCRIPTION
I tried installing testify in older versions of Octave, and wound up with errors, either at install time or at run time when calling functions. So to make things easier, add a `Depends` field to stop users from trying to use it with older versions.

As an example, in Octave 4.2

```
>> test2 version
parse error near line 861 of file /home/mike/.local/share/octave/4.2/packages/testify-0.3.3/+testify/+internal/BistRunner.m

  syntax error

>>> function out = trimleft (str)
           ^

error: called from
    test2 at line 162 column 8
```

With this PR, in Octave 4.2

```
>> pkg install testify.tar.gz
error: the following dependencies were unsatisfied:
   testify needs octave >= 4.4
```